### PR TITLE
Fix: Added Build Step to Support Render Deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "NODE_ENV=production node dist/index.js",
+    "start": "npm run build && NODE_ENV=production node dist/index.js",
     "dev": "cross-env NODE_ENV=development nodemon src/index.ts",
     "build": "tsc"
   },


### PR DESCRIPTION
What’s Done
- Updated `package.json` start script to include build step:
- `"start": "npm run build && NODE_ENV=production node dist/index.js"`
- This ensures that TypeScript is compiled before starting the server in production.
- Addresses deployment failure on Render caused by missing `/dist/index.js`.