### PR TITLE
fix: multi-stage Dockerfile & port binding for Render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,30 @@
+# ───────────── Stage 1: Build ─────────────
+FROM node:23-alpine AS builder
+
+WORKDIR /app
+
+# Only install deps (including devDeps) so TS can compile
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build   # Runs `tsc` and emits dist/
+
+# ──────────── Stage 2: Production ────────────
 FROM node:23-alpine
 
 WORKDIR /app
-COPY package.json /app
-RUN npm install
-COPY . /app
 
-ENV PORT=8000
-EXPOSE 8000
+# Install *only* production deps
+COPY package*.json ./
+RUN npm ci --omit=dev
 
-CMD ["npm", "start"]
+# Copy over compiled output
+COPY --from=builder /app/dist ./dist
+
+# Tell Docker (and Render) which port we’ll listen on…
+# (doesn't strictly enforce it, but documents intent)
+EXPOSE 10000
+
+# Start the server. No more build step here.
+CMD ["node", "dist/index.js"]

--- a/config/index.ts
+++ b/config/index.ts
@@ -2,7 +2,8 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const config = {
-  PORT: process.env.PORT || 8000,
+  // parse the string from process.env.PORT, or fall back to 8000
+  PORT: parseInt(process.env.PORT || "8000", 10),
   MONGO_URI: process.env.MONGO_URI,
   MONGO_DB_NAME: process.env.MONGO_DB_NAME || "toprak",
 

--- a/index.ts
+++ b/index.ts
@@ -3,12 +3,11 @@ import configureServer from "./server";
 import config from "./config";
 
 const app = express();
-const PORT = config.PORT || 8000;
 
 configureServer(app)
   .then(() => {
-    app.listen(PORT, () => {
-      console.log(`Server is running on port ${PORT}`);
+    app.listen(config.PORT, () => {
+      console.log(`🟢 Server is running on port ${config.PORT}`);
     });
   })
   .catch((err) => {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "npm run build && NODE_ENV=production node dist/index.js",
+    "start": "node dist/index.js",
     "dev": "cross-env NODE_ENV=development nodemon src/index.ts",
     "build": "tsc"
   },


### PR DESCRIPTION
This change refactors our Docker setup into a lean, two-stage build—compiling TypeScript in a dedicated “builder” image and then copying only the production output into the final image—and updates our server configuration so it always listens on the port provided by `process.env.PORT`, ensuring Render’s health checks pass immediately without extra recompilation at startup.
