### PR TITLE
chore: fix Docker build for Render by switching to npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,28 @@
 # ───────────── Stage 1: Build ─────────────
 FROM node:23-alpine AS builder
-
 WORKDIR /app
 
-# Only install deps (including devDeps) so TS can compile
-COPY package*.json ./
-RUN npm ci
+# Copy only the lockfile + manifest so layer caching works well
+COPY package.json package-lock.json ./
+RUN npm install
 
+# Bring in the rest of the source, then compile
 COPY . .
-RUN npm run build   # Runs `tsc` and emits dist/
+RUN npm run build   # emits dist/
 
 # ──────────── Stage 2: Production ────────────
-FROM node:23-alpine
-
+FROM node:23-alpine AS production
 WORKDIR /app
 
-# Install *only* production deps
-COPY package*.json ./
-RUN npm ci --omit=dev
+# Copy only the lockfile + manifest and install prod deps
+COPY package.json package-lock.json ./
+RUN npm install --omit=dev
 
-# Copy over compiled output
+# Copy over compiled output from builder
 COPY --from=builder /app/dist ./dist
 
-# Tell Docker (and Render) which port we’ll listen on…
-# (doesn't strictly enforce it, but documents intent)
+ENV NODE_ENV=production
 EXPOSE 10000
 
-# Start the server. No more build step here.
+# Run the compiled app
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
This update adjusts our multi-stage Dockerfile so that it:
1. Copies both package.json and package-lock.json into each build stage.
2. Uses `npm install` (and `npm install --omit=dev` in production) instead of `npm ci`, avoiding lockfile errors.
3. Leaves the build output in `dist/` and runs `node dist/index.js` on startup.
