### PR TITLE
chore: disable global Swagger auth in development

### DIFF
--- a/swagger.ts
+++ b/swagger.ts
@@ -23,6 +23,8 @@ const swaggerDefinition = {
       description: isProd ? "Production server" : "Development server",
     },
   ],
+  /*
+  // Uncomment the following sections to enable global authorization
   components: {
     securitySchemes: {
       bearerAuth: {
@@ -37,6 +39,7 @@ const swaggerDefinition = {
       bearerAuth: [],
     },
   ],
+  */
 };
 
 const options = {


### PR DESCRIPTION
To streamline front-end integration during development, this PR comments out the global `components.securitySchemes` and `security` entries in swagger.ts so that /api-docs no longer prompts for Bearer authorization. These sections are left in
the file, wrapped in comments, and can be easily re-enabled later for production.
