### PR TITLE
chore: update Swagger ‘apis’ glob to scan controllers/**/*.ts

### DIFF
--- a/swagger.ts
+++ b/swagger.ts
@@ -44,10 +44,7 @@ const swaggerDefinition = {
 
 const options = {
   definition: swaggerDefinition,
-  apis: [
-    "./api/**/*.ts", // Adjusted to match your project structure
-    "./controllers/**/*.ts",
-  ],
+  apis: ["./controllers/**/*.ts"],
 };
 
 const swaggerSpec = swaggerJSDoc(options);


### PR DESCRIPTION
This PR fixes our Swagger setup so that all controller files 
(e.g. authController.ts and teamController.ts) are picked up 
by swagger-jsdoc. It changes:

  apis: [
    "./controllers/**/*.ts"
  ]
