### PR TITLE
Enforced password strength validation in signup and reset password

### DIFF
--- a/controllers/authController.ts
+++ b/controllers/authController.ts
@@ -302,6 +302,7 @@ export const forgotPassword = async (
     await user.save();
 
     // Construct frontend reset URL
+    console.log("Frontend URL:", config.MY_APP_FRONTEND_URL);
     const resetURL = `${config.MY_APP_FRONTEND_URL}/reset-password/${resetToken}`;
 
     // Email consent
@@ -330,6 +331,9 @@ export const forgotPassword = async (
       <p style="font-size: 12px; color: #999;">&copy; ${new Date().getFullYear()} Toprak Team. All rights reserved.</p>
     </div>
   `;
+
+    console.log("RESET URL:", resetURL);
+    console.log("ENV URL:", config.MY_APP_FRONTEND_URL);
 
     // Send an email
     const mailSent = await sendEmail({


### PR DESCRIPTION
This update adds password strength validation to both the signup and reset password features. It ensures that users must create passwords with at least 8 characters, including uppercase, lowercase letters, and a number. This improves account security by preventing weak password usage.
