### PR TITLE
chore: update frontend URL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ JWT_INVITE_SECRET=your_invite_jwt_secret
 JWT_INVITE_EXPIRES_IN=1d
 
 # Frontend URL (for password reset & invitation links)
-MY_APP_FRONTEND_URL=http://localhost:5173
+MY_APP_FRONTEND_URL=https://topark-frontend.vercel.app/
 
 # SMTP Configuration (for sending emails)
 SMTP_HOST=smtp.yourprovider.com


### PR DESCRIPTION
Updated .env.example to reflect the live frontend URL instead of localhost, ensuring proper integration in production.